### PR TITLE
Update base image to node 20-bookworm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,11 +38,42 @@ jobs:
         with:
           images: keytelematics/docker-node-awscli:20
       
-      - name: Build and push Docker image
+      # - name: Build and push Node 20 Docker image
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     context: .
+      #     platforms: linux/arm64,linux/amd64
+      #     push: true
+      #     tags: keytelematics/docker-node-awscli:20
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     build-args: NODE_IMAGE=20-bookworm
+
+      # - name: Build and push Node 18 Docker image
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     context: .
+      #     platforms: linux/arm64,linux/amd64
+      #     push: true
+      #     tags: keytelematics/docker-node-awscli:18
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     build-args: NODE_IMAGE=18
+
+      # - name: Build and push Node 16 Docker image
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     context: .
+      #     platforms: linux/arm64,linux/amd64
+      #     push: true
+      #     tags: keytelematics/docker-node-awscli:16
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     build-args: NODE_IMAGE=16
+
+      - name: Build and push Node 14 Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
           platforms: linux/arm64,linux/amd64
           push: true
-          tags: keytelematics/docker-node-awscli:20
+          tags: keytelematics/docker-node-awscli:14
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: NODE_IMAGE=14.0.0-stretch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+name: Publish Docker Image 
+
+on:
+  push:
+    branches:
+      - main
+  
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: linux/arm64,linux/amd64
+
+      - name: Available platforms
+        run: echo ${{ steps.qemu.outputs.platforms }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v1
+        with:
+          images: keytelematics/docker-node-awscli:20-bookworm
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/arm64,linux/amd64
+          push: true
+          tags: keytelematics/docker-node-awscli:20-bookworm
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v1
         with:
-          images: keytelematics/docker-node-awscli:20-bookworm
+          images: keytelematics/docker-node-awscli:20
       
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
@@ -44,5 +44,5 @@ jobs:
           context: .
           platforms: linux/arm64,linux/amd64
           push: true
-          tags: keytelematics/docker-node-awscli:20-bookworm
+          tags: keytelematics/docker-node-awscli:20
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       #     push: true
       #     tags: keytelematics/docker-node-awscli:18
       #     labels: ${{ steps.meta.outputs.labels }}
-      #     build-args: NODE_IMAGE=18
+      #     build-args: NODE_IMAGE=18-bookworm
 
       # - name: Build and push Node 16 Docker image
       #   uses: docker/build-push-action@v2
@@ -60,7 +60,7 @@ jobs:
       #     push: true
       #     tags: keytelematics/docker-node-awscli:16
       #     labels: ${{ steps.meta.outputs.labels }}
-      #     build-args: NODE_IMAGE=16
+      #     build-args: NODE_IMAGE=16-bookworm
 
       - name: Build and push Node 14 Docker image
         uses: docker/build-push-action@v2
@@ -70,4 +70,4 @@ jobs:
           push: true
           tags: keytelematics/docker-node-awscli:14
           labels: node,awscli
-          build-args: NODE_IMAGE=14.0.0-stretch
+          build-args: NODE_IMAGE=14-bullseye

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,12 +32,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
       
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v1
-        with:
-          images: keytelematics/docker-node-awscli:20
-      
       # - name: Build and push Node 20 Docker image
       #   uses: docker/build-push-action@v2
       #   with:
@@ -75,5 +69,5 @@ jobs:
           platforms: linux/arm64,linux/amd64
           push: true
           tags: keytelematics/docker-node-awscli:14
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: node,awscli
           build-args: NODE_IMAGE=14.0.0-stretch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:20-bookworm
+ARG NODE_IMAGE=20-bookworm
+FROM node:${NODE_IMAGE}
 
 RUN apt-get update 
 RUN apt-get install -y python3-pip jq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM node:10
+FROM node:20-bookworm
 
-RUN apt-get update && apt-get install -y python-pip jq && \
-	pip install awscli && \
-	rm -rf /var/lib/apt/lists/*
+RUN apt-get update 
+RUN apt-get install -y python3-pip
+RUN pip3 install awscli --break-system-packages
+RUN rm -rf /var/lib/apt/lists/*
 
-RUN node --version && npm install yarn --global
+RUN node --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-bookworm
 
 RUN apt-get update 
-RUN apt-get install -y python3-pip
+RUN apt-get install -y python3-pip jq
 RUN pip3 install awscli --break-system-packages
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A custom docker-in-docker Debian Bookworm image with Node v20 and the AWS CLI pr
 https://hub.docker.com/_/node/
 Tags:
 ```
-keytelematics/docker-node-awscli:20-bookworm
-keytelematics/docker-node-awscli:20-bookworm-arm64
+keytelematics/docker-node-awscli:20
+keytelematics/docker-node-awscli:20-arm64
 ```
 
 
@@ -14,7 +14,7 @@ To build run
 `./build.sh`
 
 ### Building only for ARM
-Run `docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20-bookworm-arm64 .`
+Run `docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20-arm64 .`
 
 ### Building for only x86
-Run `docker build -t keytelematics/docker-node-awscli:20-bookworm .`
+Run `docker build -t keytelematics/docker-node-awscli:20 .`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To build run
 `./build.sh`
 
 ### Building only for ARM
-Run `docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20 .`
+Run `docker buildx build --build-arg="NODE_IMAGE=20-bookworm --platform linux/arm64 -t keytelematics/docker-node-awscli:20 .`
 
 ### Building for only x86
-Run `docker build -t keytelematics/docker-node-awscli:20 .`
+Run `docker build --build-arg="NODE_IMAGE=20-bookworm"  -t keytelematics/docker-node-awscli:20 .`

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # docker-node-awscli
 
-A custom docker-in-docker alpine image with node and the AWS CLI pre-installed.
-
-https://github.com/docker-library/docker/tree/00de5231b507c989ce900df2ef3f1abf4ce7e19c/17.09
-https://github.com/nodejs/docker-node/tree/39a5c8a3be7fff2ddc67a2e72919d0a3841b235f/8.9/alpine
-
+A custom docker-in-docker Debian Bookworm image with Node v20 and the AWS CLI pre-installed with both ARM and x86 images.
+https://hub.docker.com/_/node/
+Tags:
 ```
-docker build -t keytelematics/docker-node-awscli .
+keytelematics/docker-node-awscli:20-bookworm
+keytelematics/docker-node-awscli:20-bookworm-arm64
 ```
+
+
+## Building
+To build run 
+`./build.sh`
+
+### Building only for ARM
+Run `docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20-bookworm-arm64 .`
+
+### Building for only x86
+Run `docker build -t keytelematics/docker-node-awscli:20-bookworm .`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ https://hub.docker.com/_/node/
 Tags:
 ```
 keytelematics/docker-node-awscli:20
-keytelematics/docker-node-awscli:20-arm64
 ```
 
 
@@ -14,7 +13,7 @@ To build run
 `./build.sh`
 
 ### Building only for ARM
-Run `docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20-arm64 .`
+Run `docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20 .`
 
 ### Building for only x86
 Run `docker build -t keytelematics/docker-node-awscli:20 .`

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+echo "Building arm64 image"
+docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20-bookworm-arm64 .
+
+echo "Building default image"
+docker build -t keytelematics/docker-node-awscli:20-bookworm .

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Building arm64 image"
-docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20 .
+docker buildx build --build-arg="NODE_IMAGE=20-bookworm" --platform linux/arm64 -t keytelematics/docker-node-awscli:20 .
 
 echo "Building default image"
-docker build -t keytelematics/docker-node-awscli:20 .
+docker build --build-arg="NODE_IMAGE=20-bookworm" -t keytelematics/docker-node-awscli:20 .

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Building arm64 image"
-docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20-arm64 .
+docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20 .
 
 echo "Building default image"
 docker build -t keytelematics/docker-node-awscli:20 .

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Building arm64 image"
-docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20-bookworm-arm64 .
+docker buildx build --platform linux/arm64 -t keytelematics/docker-node-awscli:20-arm64 .
 
 echo "Building default image"
-docker build -t keytelematics/docker-node-awscli:20-bookworm .
+docker build -t keytelematics/docker-node-awscli:20 .


### PR DESCRIPTION
Updates Node version to 20-bookworm.

Also adds a script which builds the image to ARM and x86 architectures.

N.B I've removed the yarn install so any use of these images going forward will not include yarn and it must be installed separately. 